### PR TITLE
Solved the "not reloading" screen after dying with no lives

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -21,6 +21,9 @@ class Environment:
         if self.display:
             self.gym.render()
         self.observation, reward, self.terminal, info = self.gym.step(action)
+        if self.terminal:
+            print "No more lives, restarting"
+            self.gym.reset()
         return reward
 
     def getScreen(self):


### PR DESCRIPTION
Solved the "not reloading" screen after dying with no lives and --display True

Added a line to reset the environment if the game ended.
